### PR TITLE
update error check to match bimg syntax

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,8 +210,8 @@ func generateThumbnail(w http.ResponseWriter, rmethod, rpath string, sourceURL s
 
 	if err != nil {
 		responseCode := 500
-		if err.Error() == "unknown image format" {
-			responseCode = 400
+		if err.Error() == "Unsupported image format" {
+			responseCode = 415 // Unsupported Media Type
 		}
 		http.Error(w, fmt.Sprintf("resizing image: %s", err.Error()), responseCode)
 		return


### PR DESCRIPTION
Gothumb was always returning 500s since we switched to bimg and the error message changed.

I also changed the code to a more specific `415: Unsupported Media Type`

End goal here is to catch this specific error so we can stop polluting sentry from web: https://sentry.io/opendoor/web-rails/issues/496312488/events/latest/